### PR TITLE
Ensure errors reach sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ var sentry = new Sentry({
 
 ### Error
 ```javascript
-sentry.error(err, culprit, logger, extra);
+sentry.error(err, logger, culprit, extra);
 ```
 
 #### sample
@@ -56,8 +56,8 @@ sentry.error(err, culprit, logger, extra);
 ```javascript
 sentry.error(
   new Error("The error method expected an Error instance as first argument."),
-  "Bad arguments to sentry-node:error method",
   '/sentry-node.coffee',
+  "Bad arguments to sentry-node:error method",
   {
     note: "to test sentry-node error method", 
     version: "0.1.0"
@@ -70,8 +70,8 @@ This image is out of date!
 #### arguments
 
 * **err:** the error object to log, must be an instance of `Error`, `err.message` will be used for the smaller text that appears right under `culprit`
-* **culprit:** `culprit`, big text that appears at the top (you'll probably want to use something different from `err.message`)
-* **logger:** the name of the logger which created the error
+* **logger:** the name of the logger which detected the error
+* **culprit:** a string that specifies which function caused the error. If this is not known, should be `null`. If included, it the big text at the top of the sentry error.
 * **extra:** (optional) an object that gives more context about the error, it will be augmented with a field `stacktrace` containing the value of `err.stack`
 
 ### Message
@@ -120,13 +120,12 @@ sentry.on('error', function(e){
 
 ## Best Practices
 
-The Sentry client expects an instance of `Error` - it will throw an exception if not given one. This behavior is intended to align with the node.js best practice of always using `Error` instances. This means you should always take care to construct an `Error` object with an appropriate message before logging it to Sentry (really, you should always be using `Error` objects to represent error data throughout your codebase).
+The Sentry client expects an instance of `Error` - if it is given some other object, it will still send the error to Sentry, but much of the error content will be lost. This behavior is intended to align with the node.js best practice of always using `Error` instances. This means you should always take care to construct an `Error` object with an appropriate message before logging it to Sentry (really, you should always be using `Error` objects to represent error data throughout your codebase).
 
 You should always give as much context as possible with your errors. Make liberal use of the `extra` parameter to send more information that may help someone (most likely your future self) diagnose the cause of the error.
 
 If you attach other fields with important data to the `Error` instance, they will not show up in Sentry automatically. You should make sure to include those fields on the `extra` object.
 
 Sentry asks for three main fields:
-* `culprit`: who threw the exception? Commonly the name of the service.
 * `message`: what was the exception? Always the message from the passed in error.
 * `logger`: what piece of code generated the message to Sentry? Usually just whatever application actually holds the Sentry client.

--- a/lib/sentry.coffee
+++ b/lib/sentry.coffee
@@ -30,19 +30,18 @@ module.exports = class Sentry extends events.EventEmitter
       hostname: os.hostname()
       enable_env: ['production']
 
-  error: (err, culprit, logger, extra) =>
+  error: (err, logger, culprit, extra = {}) =>
     unless err instanceof Error
       console.error 'error must be an instance of Error', err
       err = new Error "WARNING: err not passed as Error! #{JSON.stringify(err, null, 2)}"
     data =
-      culprit: culprit # big text that appears at the top
       message: err.message # smaller text that appears right under culprit (and shows up in HipChat)
       logger: logger
       server_name: @hostname
       platform: 'node'
       level: 'error'
-      extra: _(extra or {}).extend
-        stacktrace: err.stack
+      extra: _.extend extra, {stacktrace: err.stack}
+    _.extend data, culprit: culprit if not _.isNull culprit
 
     @_send data
 


### PR DESCRIPTION
When given a non string logger, convert it to a string and send this to sentry (with a note saying that we had to convert the logger).
