### PR TITLE
Support promises in the wrapped function

### DIFF
--- a/lib/sentry.coffee
+++ b/lib/sentry.coffee
@@ -103,12 +103,18 @@ module.exports = class Sentry extends events.EventEmitter
     wrap:
       if @enabled
         (fn) -> (args..., cb) ->
-          fn args..., (err, results...) ->
+          ret = fn args..., (err, results...) ->
             if err?
               log_to_sentry err, {args}, (sentry_err) ->
                 cb if sentry_err? then _.extend sentry_err, original_error: err else err
             else
               cb null, results...
+          if ret && ret.then and ret.catch
+            ret.then (val) =>
+              cb null, val
+            .catch (err) =>
+              log_to_sentry err, {args}, (sentry_err) ->
+                cb if sentry_err? then _.extend sentry_err, original_error: err else err
       else
         (fn) -> fn
 

--- a/package.json
+++ b/package.json
@@ -27,15 +27,16 @@
     "url": "https://github.com/Clever/sentry-node/issues"
   },
   "dependencies": {
-    "underscore": "~1.5.2",
-    "quest": "~0.2.4",
     "debug": "~0.7.4",
-    "loofah": "0.0.6"
+    "loofah": "0.0.6",
+    "quest": "~0.2.4",
+    "underscore": "~1.5.2"
   },
   "devDependencies": {
     "coffee-script": "~1.6.3",
     "mocha": "~1.14.0",
     "nock": "~0.23.0",
-    "sinon": "^1.10.3"
+    "sinon": "^1.10.3",
+    "bluebird": "^3.4.0"
   }
 }

--- a/test/sentry.coffee
+++ b/test/sentry.coffee
@@ -3,6 +3,7 @@ assert = require 'assert'
 os = require 'os'
 nock = require 'nock'
 sinon = require 'sinon'
+Promise = require 'bluebird'
 
 Sentry = require("#{__dirname}/../lib/sentry")
 {_handle_http_429} = require("#{__dirname}/../lib/sentry")._private
@@ -327,6 +328,38 @@ describe 'Sentry', ->
         assert.deepEqual cb.firstCall.args, [_.extend timeout_error, {original_error}]
         done()
       , TIMEOUT + 2
+
+   describe 'wrapper with sentry enabled using promises', ->
+    beforeEach ->
+      sinon.spy @sentry, 'error'
+      scope = nock('https://app.getsentry.com')
+        .filteringRequestBody(/.*/, '*')
+        .post("/api/#{sentry_settings.project_id}/store/", '*')
+        .reply(200, 'OK')
+
+    afterEach ->
+      @scope.done()
+
+    it 'sends to Sentry if the given function produces an error', (done) ->
+      wrapper = @sentry.wrapper 'logger'
+      expected_err = new Error 'oops'
+      expected_args = [1, 'two', [3]]
+      wrapper.wrap((args...) -> new Promise (resolve, reject) -> setImmediate -> reject(expected_err)) expected_args..., (err) =>
+        assert.deepEqual err, expected_err
+        assert @sentry.error.calledOnce, 'Expected sentry.error to be called exactly once'
+
+        assert.deepEqual @sentry.error.firstCall.args[0..2],
+          [expected_err, 'logger', null]
+        # The 'extra' param should have the args the function was called with
+        assert.deepEqual @sentry.error.firstCall.args[3].args, expected_args
+        done()
+
+    it 'doesnt send to Sentry if the given function produces no error', (done) ->
+      wrapper = @sentry.wrapper 'logger'
+      wrapper.wrap(-> new Promise (resolve, reject) -> setImmediate -> resolve(null)) (err) =>
+        assert.deepEqual err, null
+        assert not @sentry.error.called, 'Expected sentry.error to not be called'
+        done()
 
   get_mock_data = ->
     err = new Error 'Testing sentry'


### PR DESCRIPTION
To support async/await in workers, the underlying infrastructure need to be aware of promises. In this case the wrapper function should support waiting on a promise as well as a callback.

I used the existence of `.then` and `.catch` as signals that the returned value is a Promise.

Callback code:
```
sentry_wrapper.wrap(function(arg, cb) => {
   // ...
   cb()
})
```

Promise code:
```
sentry_wrapper.wrap(async (arg) => {
   // ...
   await someOtherMethod()
})
```