### PR TITLE
Support extra params for sentry

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,13 @@ Wrapper can be used to wrap an async function, which will attempt to log any err
 sentry.wrapper(logger, timeout).wrap(some_async_func);
 ```
 
-When using wrapper, in case of an error, it's possible to pass extra context parameters by wrapping error in an object:
+When using wrapper, in case of an error, it's possible to pass extra context parameters by assigning them to the `wrapper.globals` variable:
 ```
-sentry_wrapper(logger, timeout).wrap(function(cb) {
+wrapper = sentry_wrapper(logger, timeout)
+wrapper.wrap(function(cb) {
   if (some_error_case) {
-    cb({err: new Error("error has occured"), extra: {context: "some context information to be logged"}});
+    wrapper.globals.context = "some context information to be logged";
+    cb(new Error("error has occured"));
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -99,6 +99,15 @@ Wrapper can be used to wrap an async function, which will attempt to log any err
 sentry.wrapper(logger, timeout).wrap(some_async_func);
 ```
 
+When using wrapper, in case of an error, it's possible to pass extra context parameters by wrapping error in an object:
+```
+sentry_wrapper(logger, timeout).wrap(function(cb) {
+  if (some_error_case) {
+    cb({err: new Error("error has occured"), extra: {context: "some context information to be logged"}});
+  }
+});
+```
+
 ### sample
 
 ```javascript

--- a/lib/sentry.coffee
+++ b/lib/sentry.coffee
@@ -105,7 +105,12 @@ module.exports = class Sentry extends events.EventEmitter
         (fn) -> (args..., cb) ->
           fn args..., (err, results...) ->
             if err?
-              log_to_sentry err, {args}, (sentry_err) ->
+              extra = {args}
+              if _.isObject(err) and !(err instanceof Error)
+                extra = err.extra || {}
+                extra.args = args
+                err = err.err
+              log_to_sentry err, extra, (sentry_err) ->
                 cb if sentry_err? then _.extend sentry_err, original_error: err else err
             else
               cb null, results...

--- a/lib/sentry.coffee
+++ b/lib/sentry.coffee
@@ -100,16 +100,14 @@ module.exports = class Sentry extends events.EventEmitter
 
     # Takes a function and produces a function that calls the given function, sending any errors it
     # produces to Sentry.
+    globals: {}
     wrap:
       if @enabled
-        (fn) -> (args..., cb) ->
-          fn args..., (err, results...) ->
+        (fn) -> (args..., cb) =>
+          fn args..., (err, results...) =>
             if err?
-              extra = {args}
-              if _.isObject(err) and !(err instanceof Error)
-                extra = err.extra || {}
-                extra.args = args
-                err = err.err
+              extra = this.globals
+              extra.args = args
               log_to_sentry err, extra, (sentry_err) ->
                 cb if sentry_err? then _.extend sentry_err, original_error: err else err
             else

--- a/out.txt
+++ b/out.txt
@@ -1,0 +1,1 @@
+DEBUG=* NODE_ENV=test node_modules/mocha/bin/mocha --timeout 60000 --compilers coffee:coffee-script test/sentry.coffee

--- a/test/sentry.coffee
+++ b/test/sentry.coffee
@@ -272,16 +272,19 @@ describe 'Sentry', ->
         assert not @sentry.error.called, 'Expected sentry.error to not be called'
         done()
 
-    it 'sends to Sentry if the given function produces an error and error is an object', (done) ->
+    it 'sends to Sentry if the given function produces an error and globals has value', (done) ->
       wrapper = @sentry.wrapper 'logger'
-      expected_err = {err: new Error('oops'), extra: {hello: 'world'}}
+      expected_err = new Error('oops')
       expected_args = [1, 'two', [3]]
-      wrapper.wrap((args..., cb) -> setImmediate -> cb expected_err) expected_args..., (err) =>
-        assert.deepEqual err, expected_err.err
+      wrapper.wrap((args..., cb) -> setImmediate -> 
+        wrapper.globals.hello = 'world'
+        cb expected_err
+      ) expected_args..., (err) =>
+        assert.deepEqual err, expected_err
         assert @sentry.error.calledOnce, 'Expected sentry.error to be called exactly once'
 
         assert.deepEqual @sentry.error.firstCall.args[0..2],
-          [expected_err.err, 'logger', null]
+          [expected_err, 'logger', null]
         # The 'extra' param should have the args the function was called with
         assert.deepEqual @sentry.error.firstCall.args[3].args, expected_args
         assert.deepEqual @sentry.error.firstCall.args[3].hello, 'world'


### PR DESCRIPTION
With the advent of job_id, and logging extra params in kayvee, will be great if we can get those params to show up on sentry errors as well.

I noticed it's difficult to add more parameters to the wrapper or the callback, so I propose allowing  error to be an object and so can contain extra parameters like so:
```
sentry_wrapper.wrap (raw_payload, cb) ->
   sentry_wrapper.globals.job_id = job_id
   // ...
   if err
      cb(err)
```