### PR TITLE
handle 413 in the same way we handle 429

### DIFF
--- a/lib/sentry.coffee
+++ b/lib/sentry.coffee
@@ -15,7 +15,7 @@ parseDSN = (dsn) ->
   catch err
     {}
 
-_handle_http_429 = (context, err) ->
+_handle_http_load_errors = (context, err) ->
   context.emit "warning", err
 
 # Takes an amount of time (in milliseconds) and a function and produces a function that calls the
@@ -85,7 +85,7 @@ module.exports = class Sentry extends events.EventEmitter
       json: data
     quest options, (err, res, body) =>
       if err? or res.statusCode > 299
-        return _handle_http_429 @, err if res.statusCode is 429
+        return _handle_http_load_errors @, err if res.statusCode in [429, 413]
         console.error 'Error posting event to Sentry:', err, body
         @emit("error", err)
       else
@@ -121,4 +121,4 @@ module.exports = class Sentry extends events.EventEmitter
       else
         (fn) -> fn
 
-module.exports._private = {_handle_http_429} if process.env.NODE_ENV is 'test'
+module.exports._private = {_handle_http_load_errors} if process.env.NODE_ENV is 'test'

--- a/test/sentry.coffee
+++ b/test/sentry.coffee
@@ -6,7 +6,7 @@ sinon = require 'sinon'
 Promise = require 'bluebird'
 
 Sentry = require("#{__dirname}/../lib/sentry")
-{_handle_http_429} = require("#{__dirname}/../lib/sentry")._private
+{_handle_http_load_errors} = require("#{__dirname}/../lib/sentry")._private
 sentry_settings = require("#{__dirname}/credentials").sentry
 
 
@@ -201,17 +201,16 @@ describe 'Sentry', ->
       @sentry.error new Error('Error message'), '/path/to/logger', 'culprit', extra
 
 
-  describe 'private function _handle_http_429', ->
+  describe 'private function _handle_http_load_errors', ->
     it 'exists as a function', ->
-      assert _.isFunction _handle_http_429, 'Expected Sentry to have fn _handle_http_429'
+      assert _.isFunction _handle_http_load_errors, 'Expected Sentry to have fn _handle_http_load_errors'
 
-    it 'should emit a warning when invoked', (done) ->
-      my_error = new Error 'Testing 429'
+    it 'should emit a warning when invoked with error', (done) ->
+      my_error = new Error 'Testing error'
       @sentry.once 'warning', (err) ->
         assert.equal err, my_error
         done()
-
-      _handle_http_429 @sentry, my_error
+      _handle_http_load_errors @sentry, my_error
 
   describe 'wrapper with sentry disabled', ->
     beforeEach ->


### PR DESCRIPTION
We have seen occasional issues when the err message is too large to send to sentry. At the moment the service crashes with Uncaught, Unspecified error. This is a bit of an overreaction. We should treat these errors in the same way as we do 429s.