### PR TITLE
upgrade npm

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -23,3 +23,5 @@ script:
 - npm config set ca ""
 - npm install
 - npm test
+- nvm install 0.10.29
+- nvm use 0.10.29


### PR DESCRIPTION
Previous publish failed because npm was out of date.

See https://github.com/npm/npm/issues/5032
and https://ci.ops.clever.com/github.com/Clever/sentry-node/master/e916f1178eafdc4c056aac02ef978d6fd3ead9e4