### PR TITLE
Don't use quest

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-var path = __dirname + '/' + (process.env.TEST_UNDERSTREAM_COV ? 'lib-js-cov' : 'lib-js') + '/sentry';
-module.exports = require(path);
+module.exports = require("./lib-js/sentry");

--- a/lib/sentry.coffee
+++ b/lib/sentry.coffee
@@ -1,7 +1,7 @@
 _       = require 'underscore'
 os      = require 'os'
 nodeurl = require 'url'
-quest   = require 'quest'
+request = require 'request'
 util    = require 'util'
 events  = require 'events'
 scrub   = require('loofah').default()
@@ -88,7 +88,7 @@ module.exports = class Sentry extends events.EventEmitter
       headers:
         'X-Sentry-Auth': "Sentry sentry_version=4, sentry_key=#{@key}, sentry_secret=#{@secret}, sentry_client=sentry-node"
       json: data
-    quest options, (err, res, body) =>
+    request options, (err, res, body) =>
       @emit("done")
       if err? or !res or res.statusCode > 299
         if res?.statusCode in [429, 413]

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "scripts": {
     "test": "make -Br test",
-    "test-cov": "make -Br test-cov",
     "prepublish": "make build"
   },
   "repository": {
@@ -29,7 +28,7 @@
   "dependencies": {
     "debug": "~2.6.9",
     "loofah": "0.0.6",
-    "quest": "^0.4.0",
+    "request": "^2.88.0",
     "underscore": "~1.5.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Quest imports coffeescript, which I think is sorta a poison pill for any repos that import quest. Instead lets just use the request library. 